### PR TITLE
Add model selection page for API key input

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,23 +1,12 @@
 "use client";
 
-import { Thread } from "@/components/thread";
-import { StreamProvider } from "@/providers/Stream";
-import { ThreadProvider } from "@/providers/Thread";
-import { ArtifactProvider } from "@/components/thread/artifact";
-import { Toaster } from "@/components/ui/sonner";
 import React from "react";
+import ModelSelectionPage from "@/components/model-selection-page";
 
 export default function DemoPage(): React.ReactNode {
   return (
     <React.Suspense fallback={<div>Loading (layout)...</div>}>
-      <Toaster />
-      <ThreadProvider>
-        <StreamProvider>
-          <ArtifactProvider>
-            <Thread />
-          </ArtifactProvider>
-        </StreamProvider>
-      </ThreadProvider>
+      <ModelSelectionPage />
     </React.Suspense>
   );
 }

--- a/src/components/model-selection-page.tsx
+++ b/src/components/model-selection-page.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import React from "react";
+import { PasswordInput } from "@/components/ui/password-input";
+import { Label } from "@/components/ui/label";
+
+const MODELS = ["gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo"];
+
+export default function ModelSelectionPage(): React.ReactNode {
+  const [apiKey, setApiKey] = React.useState("");
+  const [model, setModel] = React.useState<string>(MODELS[0]);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem("openai:apiKey");
+    if (stored) {
+      setApiKey(stored);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      if (apiKey) {
+        window.localStorage.setItem("openai:apiKey", apiKey);
+      } else {
+        window.localStorage.removeItem("openai:apiKey");
+      }
+    } catch {
+      // no-op
+    }
+  }, [apiKey]);
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="apiKey">OpenAI API Key</Label>
+        <PasswordInput
+          id="apiKey"
+          value={apiKey}
+          placeholder="sk-..."
+          onChange={(e) => setApiKey(e.target.value)}
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="model">Model</Label>
+        <select
+          id="model"
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          className="border-input flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-xs outline-none"
+        >
+          {MODELS.map((m) => (
+            <option
+              key={m}
+              value={m}
+            >
+              {m}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace provider-wrapped thread view with ModelSelectionPage
- add ModelSelectionPage with password input and model dropdown
- store OpenAI API key in `localStorage` and manage selected model locally

## Testing
- `pnpm lint`
- `pnpm format:check`
- `pnpm build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68b90122c4b0833396bfcf633fc77bef